### PR TITLE
Docker and pump upload limit

### DIFF
--- a/docker/dev/compose.yml
+++ b/docker/dev/compose.yml
@@ -35,7 +35,7 @@ services:
     command:
       - --storageEngine=wiredTiger
     volumes:
-      - data:/data/mongo
+      - data:/data/db
     logging:
       driver: none
     env_file:

--- a/docker/production/compose.yml
+++ b/docker/production/compose.yml
@@ -22,7 +22,7 @@ services:
     command:
       - --storageEngine=wiredTiger
     volumes:
-      - data:/data/mongo
+      - data:/data/db
     # turn off logging to save disk storage
     logging:
       driver: none

--- a/docker/test/compose.yml
+++ b/docker/test/compose.yml
@@ -21,7 +21,7 @@ services:
     command:
       - --storageEngine=wiredTiger
     volumes:
-      - data:/data/mongo
+      - data:/data/db
     # turn off logging to save disk storage
     logging:
       driver: none

--- a/nginx/production.conf
+++ b/nginx/production.conf
@@ -23,7 +23,7 @@ server {
   ssl_certificate /etc/nginx/ssl/live/dongdaminhgovap.org/fullchain.pem;
   ssl_certificate_key /etc/nginx/ssl/live/dongdaminhgovap.org/privkey.pem;
 
-  client_max_body_size 10M;
+  client_max_body_size 100M;
 
   location / {
     proxy_pass http://webapp:3000;

--- a/nginx/test.conf
+++ b/nginx/test.conf
@@ -5,7 +5,7 @@ server {
   server_name _;
   server_tokens off;
 
-  client_max_body_size 10M;
+  client_max_body_size 100M;
 
   location / {
     proxy_pass http://webapp:3000;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -60,7 +60,7 @@ export default buildConfig({
     responseOnLimit: "File không được vượt quá 10MB.",
     limits: {
       // Make sure to also update the client_max_body_size in nginx.conf if you change this
-      fileSize: 10 * 1024 * 1024, // 10 MB
+      fileSize: 100 * 1024 * 1024, // 100 MB
     },
   },
   onInit: createDefaultAdmin,


### PR DESCRIPTION
- Somehow the data is not persisted when mongo service is mounted on `data:/data/db`
- pump upload limit to 100MB